### PR TITLE
Indicator finder per Coin

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Here's your chance to see your feature request implemented.
 
 So make sure you search before creating a new issue, or you will be splintering your chances  
 
-# Price
+# Prize
 * The creator of the most-liked request will receive: 1 year free subscription of a ProfitTrailer Windows or Linux VPS from [LinkUpHost](https://linkuphost.com/clients/aff.php?aff=473).
 
 # Not allowed

--- a/README.md
+++ b/README.md
@@ -15,14 +15,13 @@ Here's your chance to see your feature request implemented.
 5. All created request need. Clear title, Description and Trading Benefit to PT
 6. Keep it positive and fun
 7. Only Feature Requests with 1337+ thumbs up Qualify
-8. Winners decided once a month
 
 ### Top 3 Qualifying Requests = guaranteed implementation in a features release
 
 So make sure you search before creating a new issue, or you will be splintering your chances  
 
 # Prize
-* The creator of the most-liked request will receive: 1 year free subscription of a ProfitTrailer Windows or Linux VPS from [LinkUpHost](https://linkuphost.com/clients/aff.php?aff=473).
+* Lifetime Multi Exchane License
 
 # Not allowed
 * Backtesting - We do not have the data nor infrastructure required to build a proper back testing logic. (Anyone can provide the data?)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Here's your chance to see your feature request implemented.
 4. Enhancements already in development or on a milestone will be closed
 5. All created request need. Clear title, Description and Trading Benefit to PT
 6. Keep it positive and fun
-7. Only Feature Requests with 1337+ thumbs up Qualify
+7. Only Feature Requests with 10+ thumbs up Qualify
 
 ### Top 3 Qualifying Requests = guaranteed implementation in a features release
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Here's your chance to see your feature request implemented.
 ## Before posting any request/issue make sure it has not been requested yet!
 
 # Where to add your request or give a thumbs up?
-https://github.com/taniman/profit-trailer-enhancements/issues
+[https://github.com/taniman/profit-trailer-enhancements/issues](https://github.com/taniman/profit-trailer-enhancements/issues)
 
 # Rules
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Here's your chance to see your feature request implemented.
 7. Only Feature Requests with 1337+ thumbs up Qualify
 8. Winners decided once a month
 
-### Top 3 Requests = guaranteed implementation in a features release
+### Top 3 Qualifying Requests = guaranteed implementation in a features release
 
 So make sure you search before creating a new issue, or you will be splintering your chances  
 

--- a/README.md
+++ b/README.md
@@ -1,43 +1,23 @@
-# The PT enhancement games  
+# PT enhancements
 May the best enhancement win!  
 
 We know you want PT to be the best.  
-Here's your chance to see your feature request implemented.
+Here's your chance to see your feature implemented.
 
 
 ## Before posting any request/issue make sure it has not been requested yet!
 
-# Where to add your request or give a thumbs up?
+# Where to add your request?
 [https://github.com/taniman/profit-trailer-enhancements/issues](https://github.com/taniman/profit-trailer-enhancements/issues)
 
 # Rules
 
-1. Create a Realistic/Bot Related Feature Requests on this project (TBD by DEV team)
+1. Create a Realistic/Bot Related Feature Request on this project (TBD by DEV team)
 2. Requests that change the fundamentals of the bot are not allowed (TBD by DEV team)
 3. Only 1 feature can be requested per issue, anything else will be closed
 4. Enhancements already in development or on a milestone will be closed
 5. All created request need. Clear title, Description and Trading Benefit to PT
-6. Keep it positive and fun
-7. Only Feature Requests with 10+ thumbs up Qualify
-
-### Top 3 Qualifying Requests = guaranteed implementation in a features release
-
-So make sure you search before creating a new issue, or you will be splintering your chances  
-
-# Prizes
-* 1st place - 600 reputation points
-* 2nd place - 300 reptationn points
-* 3rd place - 150 reputation points
 
 # Not allowed
 * Backtesting - We do not have the data nor infrastructure required to build a proper back testing logic. (Anyone can provide the data?)
-* Arbitrage - The bot is designed for trading
-
-# What is a new feature release
-PT Version Numbering starting with version 2.0  
-
-Ex: V2.1.3  
-
-2 --> Major release / New features will be added  
-1 --> Minor release / New features can be added  
-3 --> Patch release / Only bug fixes  
+* Arbitrage - We specialize in trading

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # PT enhancements
-May the best enhancement win!  
 
 We know you want PT to be the best.  
 Here's your chance to see your feature implemented.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Here's your chance to see your feature request implemented.
 So make sure you search before creating a new issue, or you will be splintering your chances  
 
 # Prizes
-* 1st place - 600 reputation points (Exchangeable for a lifetime license for example)
+* 1st place - 600 reputation points
 * 2nd place - 300 reptationn points
 * 3rd place - 150 reputation points
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ Here's your chance to see your feature request implemented.
 
 So make sure you search before creating a new issue, or you will be splintering your chances  
 
-# Prize
-* Lifetime Multi Exchane License
+# Prizes
+* 1st place - 600 reputation points (Exchangeable for a lifetime license for example)
+* 2nd place - 300 reptationn points
+* 3rd place - 150 reputation points
 
 # Not allowed
 * Backtesting - We do not have the data nor infrastructure required to build a proper back testing logic. (Anyone can provide the data?)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Here's your chance to see your feature request implemented.
 So make sure you search before creating a new issue, or you will be splintering your chances  
 
 # Price
-The creator of the most-liked request will receive: 1 year free subscription of a ProfitTrailer Windows or Linux VPS from LinkUpHost.
+* The creator of the most-liked request will receive: 1 year free subscription of a ProfitTrailer Windows or Linux VPS from [LinkUpHost](https://linkuphost.com/clients/aff.php?aff=473).
 
 # Not allowed
 * Backtesting - We do not have the data nor infrastructure required to build a proper back testing logic. (Anyone can provide the data?)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Here's your chance to see your feature request implemented.
 
 So make sure you search before creating a new issue, or you will be splintering your chances  
 
+# Price
+The creator of the most-liked request will receive: 1 year free subscription of a ProfitTrailer Windows or Linux VPS from LinkUpHost.
+
 # Not allowed
 * Backtesting - We do not have the data nor infrastructure required to build a proper back testing logic. (Anyone can provide the data?)
 * Arbitrage - The bot is designed for trading

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ May the best enhancement win!
 We know you want PT to be the best.  
 Here's your chance to see your feature request implemented.
 
+
 ## Before posting any request/issue make sure it has not been requested yet!
+
+# Where to add your request or give a thumbs up?
+https://github.com/taniman/profit-trailer-enhancements/issues
 
 # Rules
 


### PR DESCRIPTION
Hello guys,

I would like to add here my idea for an dynamic indicator finder per coin.

Lets say our important value is the "ALL_buy_value = -0.8"
Now PT looks in the indicator settings (in this example wie EMASPREAD) for the right entry point to buy the coin.

For example I will show you WTCBTC on Binance in 900 Chart.

1. WTCBTC 900sec with 24/3 and buy value -0.8

![1](https://user-images.githubusercontent.com/35115314/37052392-760a5bb8-2179-11e8-88cf-cfa00d92cf90.png)

As you can see we have 3 possible entry points (green bars) the first one is very large.

2. WTCBTC 900sec with 24/12 and buy value -0.8 (same chart & time)

![2](https://user-images.githubusercontent.com/35115314/37052448-997e16f2-2179-11e8-887e-7d799f7aca67.png)

Here we have a smaller time period and just 2 entry points

3. WTCBTC 900sec both compared

![3](https://user-images.githubusercontent.com/35115314/37052505-bb9cb8e2-2179-11e8-8382-8c01688e077b.png)

As we can see the indicator for "WTCBTC 900sec with 24/3 and buy value -0.8" would make more sense to buy because we have more entry points and a larger time range.

Now it would be great to add a module for PT which scans the indicator time compared with the buy value. The chart with the most bars pt will use. If PT will see no bar highlighting than the user should get a message please adjust you indicators manually or use dynamic indicator because PT can´t see nothing.

I hope you can benefit a little bit from this idea and build technically something great.

Thank you
